### PR TITLE
Make cookie's specific to the test page they're created on

### DIFF
--- a/test/html/checkCookieExists.html
+++ b/test/html/checkCookieExists.html
@@ -34,7 +34,7 @@
             const d = new Date();
             d.setTime(d.getTime() + (exdays*24*60*60*1000));
             const expires = "expires="+ d.toUTCString();
-            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+            document.cookie = cname + "=" + cvalue + ";" + expires;
             document.getElementById("existing-cookie").innerHTML = "Cookies associated with this document: " + document.cookie;
         }
 

--- a/test/html/deleteCookie.html
+++ b/test/html/deleteCookie.html
@@ -34,7 +34,7 @@
             const d = new Date();
             d.setTime(d.getTime() + (exdays*24*60*60*1000));
             const expires = "expires="+ d.toUTCString();
-            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+            document.cookie = cname + "=" + cvalue + ";" + expires;
             document.getElementById("existing-cookie").innerHTML = "Cookies associated with this document: " + document.cookie;
         }
 


### PR DESCRIPTION
@valentinmagot I realized that creating a new `deleteCookie.html` was not enough since the cookies were being set for the whole domain with `path=/`.  This fixes it so that cookies are only set for each page.