### PR TITLE
Added checkTitleContains steps and tests

### DIFF
--- a/features/checkTitle.feature
+++ b/features/checkTitle.feature
@@ -1,0 +1,8 @@
+Feature: checkTitle
+  In order write BDD tests
+  As a developer
+  I want check the page's title
+  
+  Scenario: Check title
+    When  I open the url "http://localhost:8080/checkTitle.html"
+    Then  I expect that the title is "checkTitle - Test"    

--- a/features/checkTitleContains.feature
+++ b/features/checkTitleContains.feature
@@ -1,0 +1,13 @@
+Feature: checkTitleContains
+  In order write BDD tests
+  As a developer
+  I want to check if a title contains the appropriate content
+
+  Scenario: Check page title contains appropriate title
+    When  I open the url "http://localhost:8080/checkTitleContains.html"
+    Then   I expect "checkTitle" to be contained in page title
+    And    I expect "notMatchingTitle - Test" not to be contained in page title
+
+    Scenario: Check page title contains given title
+    Given  "Title" to be contained in page title
+    Then   I expect that the title is "checkTitleContains - Test"

--- a/features/steps/given.js
+++ b/features/steps/given.js
@@ -12,6 +12,7 @@ const checkIsChecked = require('../support/check/checkIsChecked');
 const checkCookieExists = require("../support/check/checkCookieExists");
 const checkCookieValue = require("../support/check/checkCookieValue");
 const openUrl = require('../support/action/openUrl');
+const checkTitleContains = require("../support/check/checkTitleContains");
 
 Given(
     /^the url "([^"]*)?" is opened$/, 
@@ -83,4 +84,9 @@ Given(
 Given(
     /^the cookie "([^"]*)?"( not)* exist?$/,
     checkCookieExists
+);
+
+Given(
+    /^"([^"]*)?"( not)* to be contained in page title$/, 
+    checkTitleContains
 );

--- a/features/steps/then.js
+++ b/features/steps/then.js
@@ -12,6 +12,8 @@ const checkHasFocus = require("../support/check/checkHasFocus");
 const checkIsChecked = require('../support/check/checkIsChecked');
 const checkCookieExists = require("../support/check/checkCookieExists");
 const checkCookieValue = require("../support/check/checkCookieValue");
+const resizeScreenSize = require("../support/action/resizeScreenSize");
+const checkTitleContains = require("../support/check/checkTitleContains");
 
 Then(
     /^I expect that the title is "([^"]*)"$/, 
@@ -83,4 +85,14 @@ Then(
 Then(
     /^I expect the cookie "([^"]*)?"( not)* exist?$/,
     checkCookieExists
+);
+
+Then(
+    /^I resize the browser to (\d+) pixels width and (\d+) pixels height$/,
+    resizeScreenSize
+);
+
+Then(
+    /^I expect "([^"]*)"( not)* to be contained in page title$/,
+    checkTitleContains
 );

--- a/features/support/check/checkTitleContains.js
+++ b/features/support/check/checkTitleContains.js
@@ -1,0 +1,15 @@
+const assert = require('assert').strict;
+
+/**
+ * Checks the web page `<title>` content.
+ * @param {String} expectedTitle Expected title to check if the web page contains.
+ * @param {String} not String "not" to indicate that the element should not have the given text.
+ */
+module.exports = async function (expectedTitle, not) {
+    
+    const titleValue = await this.page.title();
+    const containsTitle =  titleValue && expectedTitle && titleValue.includes(expectedTitle);
+    const shouldContainExpectedTitle = not ? false : true;
+
+    assert.strictEqual(containsTitle, shouldContainExpectedTitle, `Expected "${titleValue}" to ${shouldContainExpectedTitle ? 'contain' : 'not contain'} "${expectedTitle}"`);
+}

--- a/test/check/checkTitleContains.test.js
+++ b/test/check/checkTitleContains.test.js
@@ -1,0 +1,49 @@
+const checkTitleContains = require('../../features/support/check/checkTitleContains');
+const openUrl = require('../../features/support/action/openUrl');
+const BrowserScope = require('../../features/support/scope/BrowserScope');
+
+
+const testUrl = 'http://localhost:8080/checkTitleContains.html';
+const browserScope = new BrowserScope();
+
+beforeAll(async () => {
+  await browserScope.init();
+  await openUrl.call(browserScope, testUrl);
+});
+afterAll(async () => {
+  await browserScope.close();
+});
+
+describe('checkTitleContains', () => {
+
+  it('finds subpart of the title', async () => {   
+    await checkTitleContains.call(browserScope, 'Test');
+    await checkTitleContains.call(browserScope, '-');
+    await checkTitleContains.call(browserScope, 'checkTit');
+    await checkTitleContains.call(browserScope, ' ');
+  });
+
+  it('finds full matches of title', async () => {   
+    await checkTitleContains.call(browserScope, 'checkTitleContains - Test');
+  });
+
+  it('identifies non-subpart of the title', async () => {    
+    await checkTitleContains.call(browserScope, 'notMatchingTitle - Test', 'not');
+    await checkTitleContains.call(browserScope, '-Test', 'not');
+  });
+
+  it("fails when told that title should contain a specific text, but it doesn't actually contain it", async () => {
+    await expect(checkTitleContains.call(browserScope, 'notMatchingTitle - Test')).rejects.toThrow('Expected "checkTitleContains - Test" to contain "notMatchingTitle - Test"');
+  });
+  
+  it('fails when told that title should not contain a specific text, but it does actually contain it', async () => {
+    await expect(checkTitleContains.call(browserScope, 'checkTitleContains - Test', 'not')).rejects.toThrow('Expected "checkTitleContains - Test" to not contain "checkTitleContains - Test"');
+  });
+
+  it('fails when title is empty', async () => {   
+    await expect(checkTitleContains.call(browserScope, '')).rejects.toThrow('Expected "checkTitleContains - Test" to contain ""');
+    await expect(checkTitleContains.call(browserScope, null)).rejects.toThrow('Expected "checkTitleContains - Test" to contain "null"');
+    await expect(checkTitleContains.call(browserScope, undefined)).rejects.toThrow('Expected "checkTitleContains - Test" to contain "undefined"');
+  }); 
+
+}); 

--- a/test/html/checkTitleContains.html
+++ b/test/html/checkTitleContains.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>checkTitleContains - Test</title>
+</head>
+<body>
+    <h1>checkTitleContains</h1>
+</body>
+</html>


### PR DESCRIPTION
### Details
This feature checks if the web page `<title>` contains a specific text.

### Observation
I am not sure if this is what you are looking for since it seems pretty similar to the `checkTitle` feature.
Since there is a step definition for the `checkTitle` feature inside the `/then` folder i added a file to demonstrate it, i wasn't sure if it is needed.