### PR TITLE
Add support for environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+ROOT_URL=http://localhost:8080
+SCREENSHOT_PATH=./test/screenshots
+TEST_PASSWORD=pass

--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
-
 # next.js build output
 .next
 

--- a/features/checkAttributes.feature
+++ b/features/checkAttributes.feature
@@ -4,7 +4,7 @@ Feature: checkAttribute
   I want to check if an element's attribute has a specific value
 
   Scenario: Check attributes
-    When  I open the url "http://localhost:8080/checkAttribute.html"
+    When  I open the url "$CHECK_ATTRIBUTE_URL"
     Then  I expect the attribute "class" from element "#cssClass" is "foobar bambaz"
     And   I expect the attribute "href" from element "#href" is "/somepage"
     And   I expect the attribute "data-favorite-snack" from element "ul" is "muffins" 

--- a/features/checkAttributes.feature
+++ b/features/checkAttributes.feature
@@ -4,7 +4,7 @@ Feature: checkAttribute
   I want to check if an element's attribute has a specific value
 
   Scenario: Check attributes
-    When  I open the url "$CHECK_ATTRIBUTE_URL"
+    When  I open the url "http://localhost:8080/checkAttribute.html"
     Then  I expect the attribute "class" from element "#cssClass" is "foobar bambaz"
     And   I expect the attribute "href" from element "#href" is "/somepage"
     And   I expect the attribute "data-favorite-snack" from element "ul" is "muffins" 

--- a/features/openUrl.feature
+++ b/features/openUrl.feature
@@ -7,6 +7,6 @@ Feature: openUrl
     Given the url "http://localhost:8080/checkTitle.html" is opened
     Then  I expect the page url is "http://localhost:8080/checkTitle.html"
 
-  Scenario: Open a URL in a when step
-    When  I open the url "http://localhost:8080/waitFor.html"
+  Scenario: Open a URL in a when step using a root URL environment variable
+    When  I open the url "/waitFor.html"
     Then  I expect the page url is "http://localhost:8080/waitFor.html"

--- a/features/setElementValue.feature
+++ b/features/setElementValue.feature
@@ -8,6 +8,8 @@ Feature: setElementValue
     And   I set the element ".enabled" value to "rick"
     And   I set the element "select[name='cartoon-characters']" value to "morty"
     And   I set the element "textarea" value to "Meeseeks and Destroys"
+    And   I set the element "[type='password']" value to "$TEST_PASSWORD"
     Then  the element ".enabled" value is "rick"
     And   the element "select[name='cartoon-characters']" value is "morty"
     And   the element "textarea" value is "Meeseeks and Destroys"
+    And   the element "[type='password']" value is "pass"

--- a/features/steps/when.js
+++ b/features/steps/when.js
@@ -8,7 +8,7 @@ const resizeScreenSize = require('../support/action/resizeScreenSize')
 const scrollToElement = require('../support/action/scrollToElement');
 
 When(
-    /^I open the url "([^"]*)?"$/, 
+    'I open the url {env}', 
     openUrl
 );
 

--- a/features/steps/when.js
+++ b/features/steps/when.js
@@ -8,36 +8,37 @@ const resizeScreenSize = require('../support/action/resizeScreenSize')
 const scrollToElement = require('../support/action/scrollToElement');
 
 When(
-    'I open the url {env}', 
+    'I open the url {string-env}', 
     openUrl
 );
 
 When(
+    // Used RegEx since cucumber expressions do not have a good way to do optional capturing groups that return their value
     /^I click the (?:element|button|link) "([^"]*)?"( and wait for the page to load)?$/, 
     clickElement
 );
 
 When(
-    /^I set the (?:element|input|select|textarea) "([^"]*)?" value to "([^"]*)?"$/, 
+    'I set the element/input/select/textarea {string} value to {string-env}', 
     setElementValue
 );
 
 When(
-    /^I wait for "([^"]*)?" seconds$/, 
+    'I wait for {float} seconds', 
     waitFor
 );
 
 When(
-    /^I delete the cookie "([^"]*)?"$/, 
+    'I delete the cookie {string-env}', 
     deleteCookie
 );
 
 When(
-    /^I set the browser viewport to (\d+)px width by (\d+)px height$/,
+    'I set the browser viewport to {int}px width by {int}px height',
     resizeScreenSize
 );
 
 When(
-    /^I scroll to the element "([^"]*)?"$/, 
+    'I scroll to the element {string}', 
     scrollToElement
 );

--- a/features/support/action/waitFor.js
+++ b/features/support/action/waitFor.js
@@ -1,16 +1,11 @@
 /**
  * Wait for a given number of seconds.
- * @param {String} secondsStr The number of seconds to wait.
+ * @param {Float} seconds The number of seconds to wait.
  */
-module.exports = async function(secondsStr) {
-    const seconds = Number(secondsStr);
-
-    
-
-    // Make sure we've got a valid number that's greater than 0
-    if(!isNaN(seconds) && seconds > 0){
+module.exports = async function(seconds) {
+    if(seconds > 0){
         await this.page.waitFor(seconds * 1000);
     } else {
-        throw new Error(`Error: "${secondsStr}" is not a valid time to wait`);
+        throw new Error(`Error: "${seconds}" is not a valid time to wait`);
     }
 };

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -7,26 +7,21 @@ const FeatureScope = require('./scope/FeatureScope');
 const BrowserScope = require('./scope/BrowserScope');
 const { createFolder } = require('./util/FileSystem');
 
+// Process .env file
+require('dotenv').config()
+
 // Timeout, in milliseconds, for puppeteer actions
 setDefaultTimeout(10 * 1000);
 
 // `BrowserScope` is provided to all hooks and test steps in a scenario as `this`
 setWorldConstructor(BrowserScope)
 
-// Environment variable parameter type
-process.env.CHECK_ATTRIBUTE_URL = 'http://localhost:8080/checkAttribute.html';
+// String environment variable.  If the string value starts with '$', it's assumed to be the key for an environment variable.
 defineParameterType({
   regexp: /"([^"]*)"/,
-  transformer: (string) => {
-      let value = string;
-      if(string.startsWith('$')){
-        value = process.env[string.slice(1)];
-      }
-      return value;
-  },
-  name: 'env',
-  useForSnippets: false,
-  preferForRegexpMatch: true
+  transformer: (string) => string.startsWith('$') ? process.env[string.slice(1)] : string,
+  name: 'string-env',
+  useForSnippets: false
 });
 
 // Keep a consistent web browser and page for all scenarios in a feature file.

--- a/features/support/config.js
+++ b/features/support/config.js
@@ -2,7 +2,7 @@
  * Configure the test suite
  * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md
  */
-const { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout, setWorldConstructor } = require('cucumber');
+const { After, AfterAll, Before, BeforeAll, Status, defineParameterType, setDefaultTimeout, setWorldConstructor } = require('cucumber');
 const FeatureScope = require('./scope/FeatureScope');
 const BrowserScope = require('./scope/BrowserScope');
 const { createFolder } = require('./util/FileSystem');
@@ -12,6 +12,22 @@ setDefaultTimeout(10 * 1000);
 
 // `BrowserScope` is provided to all hooks and test steps in a scenario as `this`
 setWorldConstructor(BrowserScope)
+
+// Environment variable parameter type
+process.env.CHECK_ATTRIBUTE_URL = 'http://localhost:8080/checkAttribute.html';
+defineParameterType({
+  regexp: /"([^"]*)"/,
+  transformer: (string) => {
+      let value = string;
+      if(string.startsWith('$')){
+        value = process.env[string.slice(1)];
+      }
+      return value;
+  },
+  name: 'env',
+  useForSnippets: false,
+  preferForRegexpMatch: true
+});
 
 // Keep a consistent web browser and page for all scenarios in a feature file.
 const featureScope = new FeatureScope();
@@ -28,9 +44,9 @@ const config = {
   // Path used by checkScreenshot visual regression tests to save and compare screenshotss
   // Defaults to /test/screenshots if a SCREENSHOT_PATH environment variable isn't pressent.  
   screenshotPath: process.env.SCREENSHOT_PATH ? process.env.SCREENSHOT_PATH : './test/screenshots'
-} 
+}
 
-// Run once before tests
+// Create required folders
 BeforeAll(async function(){
   await createFolder(`${config.screenshotPath}/compare`);
   await createFolder(`${config.screenshotPath}/diff`);
@@ -38,7 +54,8 @@ BeforeAll(async function(){
   await createFolder(`${config.screenshotPath}/ref`);
 });
 
-// Before hook for each scenario
+
+// Use the same BrowserScope object for each scenario in a feature
 Before(async function(scenario) {
 
   // Check if the current scenario is in the same feature test

--- a/features/waitFor.feature
+++ b/features/waitFor.feature
@@ -10,5 +10,5 @@ Feature: waitFor
   Scenario: After waiting for 2 seconds, the element is visible
     Given the url "http://localhost:8080/waitFor.html" is opened
     And   the element ".starts-hidden" is not visible    
-    And   I wait for "2.5" seconds
+    And   I wait for 2.5 seconds
     Then  I expect the element ".starts-hidden" is visible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-puppeteer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1052,6 +1052,11 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
     },
     "duration": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/patheard/cucumber-puppeteer#readme",
   "dependencies": {
     "cucumber": "^5.1.0",
+    "dotenv": "^7.0.0",
     "pixelmatch": "^4.0.2",
     "puppeteer": "^1.13.0"
   },

--- a/test/html/setElementValue.html
+++ b/test/html/setElementValue.html
@@ -10,6 +10,7 @@
     <input type="text" name="enabled" class="enabled" value="some filler value">
     <input type="text" name="disabled" disabled>
     <input type="text" name="readonly" readonly>
+    <input type="password" name="environment-variable-example">
 
     <textarea name="description"></textarea>
 


### PR DESCRIPTION
Rewrote when.js step definitions using CukeXP and custom parameter type {string-env}, which checks
if the passed string value starts with '$'.  If it does, it's assumed to be an environment variable.