### PR TITLE
Change click action to use JS click()

### DIFF
--- a/features/support/action/clickElement.js
+++ b/features/support/action/clickElement.js
@@ -1,5 +1,6 @@
 /**
- * Clicks on an item.
+ * Clicks on an item.  Uses the DOM click() method since Puppeteer `page.click(selector)` behaves
+ * inconsistently.
  * @param {String} selector CSS selector of the item to click.
  * @param {String} waitForSelector If not null, the selector that should exist after the click.
  * test should allow to complete.
@@ -7,13 +8,15 @@
 module.exports = async function(selector, waitForSelector) {
     // Wait until the given selector exists
     if(waitForSelector){
+        /* istanbul ignore next */
         await Promise.all([
             this.page.waitForSelector(waitForSelector),
-            this.page.click(selector)
+            this.page.$eval(selector, e => e.click())
         ]);
 
     // Nothing to wait for, just click
-    } else {               
-        await this.page.click(selector);
+    } else {
+        /* istanbul ignore next */
+        await this.page.$eval(selector, e => e.click());
     }
 };

--- a/test/action/clickElement.test.js
+++ b/test/action/clickElement.test.js
@@ -38,7 +38,7 @@ describe('clickElement', () => {
   });    
 
   it('fails if the element does not exist', async () => {
-    await expect(clickElement.call(browserScope, '.bueller')).rejects.toThrow("No node found for selector: .bueller");
+    await expect(clickElement.call(browserScope, '.bueller')).rejects.toThrow('Error: failed to find element matching selector ".bueller"');
   });  
 
 }); 


### PR DESCRIPTION
Puppeteer click is behaving inconsistently and page.click(selector) actions are not working in all cases.

Closes #86 