### PR TITLE
Revert clickElement to puppeteer.click

### DIFF
--- a/features/support/action/clickElement.js
+++ b/features/support/action/clickElement.js
@@ -1,6 +1,5 @@
 /**
- * Clicks on an item.  Uses the DOM click() method since Puppeteer `page.click(selector)` behaves
- * inconsistently.
+ * Clicks on an item. 
  * @param {String} selector CSS selector of the item to click.
  * @param {String} waitForSelector If not null, the selector that should exist after the click.
  * test should allow to complete.
@@ -8,15 +7,13 @@
 module.exports = async function(selector, waitForSelector) {
     // Wait until the given selector exists
     if(waitForSelector){
-        /* istanbul ignore next */
         await Promise.all([
             this.page.waitForSelector(waitForSelector),
-            this.page.$eval(selector, e => e.click())
+            this.page.click(selector)
         ]);
 
     // Nothing to wait for, just click
     } else {
-        /* istanbul ignore next */
-        await this.page.$eval(selector, e => e.click());
+        await this.page.click(selector);
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-puppeteer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A Node.js template for end-to-end testing your app with Cucumber.js and Puppeteer",
   "main": "index.js",
   "files": [

--- a/test/action/clickElement.test.js
+++ b/test/action/clickElement.test.js
@@ -38,7 +38,7 @@ describe('clickElement', () => {
   });    
 
   it('fails if the element does not exist', async () => {
-    await expect(clickElement.call(browserScope, '.bueller')).rejects.toThrow('Error: failed to find element matching selector ".bueller"');
+    await expect(clickElement.call(browserScope, '.bueller')).rejects.toThrow('No node found for selector: .bueller');
   });  
 
 }); 


### PR DESCRIPTION
Using the DOM $eval element.click() was not scrolling
to elements that are out of view, so click testing was
more difficult (required a scroll into view step).