### PR TITLE
Puppeteer coverage support

### DIFF
--- a/features/support/action/openUrl.js
+++ b/features/support/action/openUrl.js
@@ -11,8 +11,6 @@ const puppeteer = require('puppeteer');
 module.exports = async function(url, userAgent, device) {
     const fullUrl = url.match(/^http.*$/i) ? url : this.config.rootUrl + url;
 
-    this.page = await this.browser.newPage();
-
     // Set the user agent if it exists
     if(userAgent){
         await this.page.setUserAgent(userAgent);

--- a/features/support/scope/BrowserScope.js
+++ b/features/support/scope/BrowserScope.js
@@ -19,9 +19,9 @@ class BrowserScope {
         }
         this.close();
 
-        this.page = null;
         this.config = {};
         this.browser = await puppeteer.launch({...defaultOptions, ...puppeteerOptions, ...this.worldParameters});
+        this.page = await this.browser.newPage();
     }
 
     async close(){

--- a/features/support/scope/FeatureScope.js
+++ b/features/support/scope/FeatureScope.js
@@ -8,6 +8,8 @@ class FeatureScope {
     constructor(){
         this.browserScope = null;
         this.feature = null;
+        this.coverageJs = null;
+        this.coverageCss = null;
     }
 
     /**
@@ -26,13 +28,31 @@ class FeatureScope {
     async init(currentFeature, worldParameters){
         this.feature = currentFeature;
         
-        if(this.browserScope){            
+        if(this.browserScope){
             await this.browserScope.close();
             this.browserScope = null;
         }
         
         this.browserScope = new BrowserScope({parameters: worldParameters});
         await this.browserScope.init();
+    }
+
+    async coverageStart(){
+        if(this.browserScope && this.browserScope.page){
+            await Promise.all([
+                this.browserScope.page.coverage.startJSCoverage(),
+                this.browserScope.page.coverage.startCSSCoverage()
+            ]);
+        }
+    }
+
+    async coverageStop(){
+        if(this.browserScope && this.browserScope.page){
+            [this.coverageJs, this.coverageCss] = await Promise.all([
+                this.browserScope.page.coverage.stopJSCoverage(),
+                this.browserScope.page.coverage.stopCSSCoverage(),
+            ]);        
+        }
     }
 }
 

--- a/test/scope/BrowserScope.test.js
+++ b/test/scope/BrowserScope.test.js
@@ -15,7 +15,7 @@ describe('BrowserScope', () => {
   it('can be initialized', async () => {
     browserScope = new BrowserScope({parameters: {headless: true}});
     await browserScope.init();    
-    expect(browserScope.page).toBe(null);
+    expect(browserScope.page).not.toBe(null);
     expect(browserScope.config).not.toBe(null);
     expect(browserScope.browser).not.toBe(null);
     expect(browserScope.worldParameters).toEqual({headless: true});

--- a/test/scope/FeatureScope.test.js
+++ b/test/scope/FeatureScope.test.js
@@ -11,7 +11,8 @@ describe('FeatureScope', () => {
   it('starts out uninitialized', async () => {    
     featureScope = new FeatureScope();
     expect(featureScope.browserScope).toBe(null);
-    expect(featureScope.feature).toBe(null);
+    expect(featureScope.coverageJs).toBe(null);
+    expect(featureScope.coverageCss).toBe(null);
   });
 
   it('can be initialized', async () => {
@@ -21,6 +22,8 @@ describe('FeatureScope', () => {
     expect(featureScope.feature).toBe('mmmuffins');
     expect(featureScope.browserScope).not.toBe(null);
     expect(featureScope.browserScope.worldParameters).toEqual({});
+    expect(featureScope.coverageJs).toBe(null);
+    expect(featureScope.coverageCss).toBe(null);    
   });
   
   it('can close an existing browser scope object', async () => {
@@ -38,5 +41,27 @@ describe('FeatureScope', () => {
     expect(featureScope.isNewFeature('mmmuffins')).toBe(false);
     expect(featureScope.isNewFeature('pants')).toBe(true);
   });
+
+  it('does not capture JS/CSS coverage when BrowserScope is not initialized', async () => { 
+    await featureScope.browserScope.close();
+    expect(featureScope.coverageJs).toBe(null);
+    expect(featureScope.coverageCss).toBe(null); 
+
+    await featureScope.coverageStart();
+    await featureScope.coverageStop();
+    expect(featureScope.coverageJs).toBe(null);
+    expect(featureScope.coverageCss).toBe(null);  
+  });  
+
+  it('can start and stop JS/CSS coverage reporting when BrowserScope is initialized', async () => { 
+    await featureScope.init();
+    expect(featureScope.coverageJs).toBe(null);
+    expect(featureScope.coverageCss).toBe(null);
+
+    await featureScope.coverageStart();
+    await featureScope.coverageStop();
+    expect(featureScope.coverageJs).toEqual([]);
+    expect(featureScope.coverageCss).toEqual([]);    
+  });  
 
 }); 


### PR DESCRIPTION
* Adds the ability for the `FeatureScope` to start and stop Puppeteer's JS/CSS coverage.
* Puppeteer `BrowserScope.init` now creates the Page object.

Related to #103 