### PR TITLE
Support attachments in test steps

### DIFF
--- a/features/support/scope/BrowserScope.js
+++ b/features/support/scope/BrowserScope.js
@@ -10,6 +10,7 @@ class BrowserScope {
         this.config = null;
         this.page = null;
         this.worldParameters = args && args.parameters ? args.parameters : {};
+        this.attach = args && args.attach ? args.attach : null;
     }
 
     async init(){

--- a/features/support/util/PrettyFormatter.js
+++ b/features/support/util/PrettyFormatter.js
@@ -28,10 +28,20 @@ class PrettyFormatter extends SummaryFormatter {
   }
 
   logTestStep({testCase, index, result}) {
-    const {gherkinKeyword, pickleStep} = this.eventDataCollector.getTestStepData({testCase, index});
+    const {gherkinKeyword, pickleStep, testStep} = this.eventDataCollector.getTestStepData({testCase, index});
     const {status} = result;
+
+    // Log the step
     if (pickleStep) {
-      this.log(`   ${this.colorFns[status](STATUS_CHARACTER_MAPPING[status])} ${gherkinKeyword}${pickleStep.text}\n`);
+      this.log(`   ${this.colorFns[status](STATUS_CHARACTER_MAPPING[status])} ${gherkinKeyword}${pickleStep.text}\n`);      
+    }
+
+    // Log attachments for the test step
+    if(testStep && testStep.attachments){
+      for(const attachment of testStep.attachments){
+        const type = attachment.media.type;
+        this.log(`     ${this.colorFns['location'](`Attachment (${type})${type === 'text/plain' ? ': ' + attachment.data : ''}`)}\n`);
+      }
     }
   }
 

--- a/test/scope/BrowserScope.test.js
+++ b/test/scope/BrowserScope.test.js
@@ -10,15 +10,17 @@ describe('BrowserScope', () => {
     expect(browserScope.browser).toBe(null);
     expect(browserScope.config).toBe(null);
     expect(browserScope.worldParameters).toEqual({});
+    expect(browserScope.attach).toBe(null);
   });
 
   it('can be initialized', async () => {
-    browserScope = new BrowserScope({parameters: {headless: true}});
+    browserScope = new BrowserScope({attach: {}, parameters: {headless: true}});
     await browserScope.init();    
     expect(browserScope.page).not.toBe(null);
     expect(browserScope.config).not.toBe(null);
     expect(browserScope.browser).not.toBe(null);
     expect(browserScope.worldParameters).toEqual({headless: true});
+    expect(browserScope.attach).toEqual({});
 
     const browserVersion = await browserScope.browser.version();
     expect(browserVersion).toContain('Chrome');


### PR DESCRIPTION
A `this.attach` has been added to BrowserScope that allows
steps to attach data.  The PrettyFormatter has also been updated
to output `text/plain` attachments.

Fixes #109